### PR TITLE
Match how controller firmware adjusts region and powerlevels

### DIFF
--- a/app.c
+++ b/app.c
@@ -98,9 +98,11 @@ ZW_APPLICATION_STATUS ApplicationInit(__attribute__((unused)) zpal_reset_reason_
 
   RadioConfig = zaf_get_radio_config();
 
+  bool nvm_init_done = ZAF_nvm_app_init();
+
   // Mirror how the controller firmware handles radio settings,
   // namely using the mfg token only as a fallback.
-  if (RepeaterConfigExists()) {
+  if (nvm_init_done && RepeaterConfigExists()) {
     ReadApplicationRfRegion(&RadioConfig->eRegion);
     ReadApplicationTxPowerlevel(&RadioConfig->iTxPowerLevelMax,
                                 &RadioConfig->iTxPowerLevelAdjust);
@@ -111,7 +113,9 @@ ZW_APPLICATION_STATUS ApplicationInit(__attribute__((unused)) zpal_reset_reason_
       RadioConfig->eRegion = regionMfg;
     }
 
-    RepeaterConfigWriteDefaults(RadioConfig);
+    if (nvm_init_done) {
+      RepeaterConfigWriteDefaults(RadioConfig);
+    }
   }
 
   /*

--- a/app.c
+++ b/app.c
@@ -29,6 +29,7 @@
 #endif
 #include "ZW_UserTask.h"
 #include "app_led_task.h"
+#include "repeater_config_nvm.h"
 #include "CC_ColorSwitch.h"
 #include "cc_color_switch_config_api.h"
 #include "cc_color_switch_io.h"
@@ -85,6 +86,7 @@ bool restore_color_switch_cc_state() {
 ZW_APPLICATION_STATUS ApplicationInit(__attribute__((unused)) zpal_reset_reason_t eResetReason)
 {
   SRadioConfig_t* RadioConfig;
+  zpal_radio_region_t regionMfg;
 
   zpal_enable_watchdog(true);
 
@@ -96,13 +98,20 @@ ZW_APPLICATION_STATUS ApplicationInit(__attribute__((unused)) zpal_reset_reason_
 
   RadioConfig = zaf_get_radio_config();
 
-  // Read Rf region from MFG_ZWAVE_COUNTRY_FREQ
-  zpal_radio_region_t regionMfg;
-  ZW_GetMfgTokenDataCountryFreq((void*) &regionMfg);
-  if (isRfRegionValid(regionMfg)) {
-    RadioConfig->eRegion = regionMfg;
+  // Mirror how the controller firmware handles radio settings,
+  // namely using the mfg token only as a fallback.
+  if (RepeaterConfigExists()) {
+    ReadApplicationRfRegion(&RadioConfig->eRegion);
+    ReadApplicationTxPowerlevel(&RadioConfig->iTxPowerLevelMax,
+                                &RadioConfig->iTxPowerLevelAdjust);
+    ReadApplicationMaxLRTxPwr(&RadioConfig->iTxPowerLevelMaxLR);
   } else {
-    ZW_SetMfgTokenDataCountryRegion((void*) &RadioConfig->eRegion);
+    ZW_GetMfgTokenDataCountryFreq((void*) &regionMfg);
+    if (isRfRegionValid(regionMfg)) {
+      RadioConfig->eRegion = regionMfg;
+    }
+
+    RepeaterConfigWriteDefaults(RadioConfig);
   }
 
   /*

--- a/app_cli.c
+++ b/app_cli.c
@@ -47,6 +47,7 @@
 #include "ev_man.h"
 #include "events.h"
 #include "zaf_config.h"
+#include "zaf_protocol_config.h"
 #include "zpal_misc.h"
 #include "zpal_radio.h"
 

--- a/app_cli.c
+++ b/app_cli.c
@@ -31,9 +31,7 @@
 // -----------------------------------------------------------------------------
 //                                   Includes
 // -----------------------------------------------------------------------------
-#include <errno.h>
 #include <stdbool.h>
-#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <strings.h>
@@ -64,13 +62,13 @@ typedef struct {
 
 #define TX_POWER_LIMIT_MIN_DDBM     (-100)
 #define TX_POWER_ADJUST_LIMIT_DDBM  (100)
+#define DBM_TO_DDBM(value)          ((value) * 10)
 #define CLI_REBOOT_DELAY_MS         (50)
 
 // -----------------------------------------------------------------------------
 //                          Static Function Declarations
 // -----------------------------------------------------------------------------
 static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *region);
-static bool sli_try_parse_tx_power(const char *value, zpal_tx_power_t *tx_power);
 static const char *sli_get_region_name(zpal_radio_region_t region);
 static void sli_reboot_after_cli_delay(void);
 static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
@@ -193,9 +191,6 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
   zpal_tx_power_t tx_power_level;
   zpal_tx_power_t tx_power_adjust;
   zpal_tx_power_t max_tx_power_lr;
-  const char *tx_power_level_str;
-  const char *tx_power_adjust_str;
-  const char *max_tx_power_lr_str;
   bool requires_reboot;
 
   if (sl_cli_get_argument_count(arguments) != 3) {
@@ -203,16 +198,9 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
     return;
   }
 
-  tx_power_level_str = sl_cli_get_argument_string(arguments, 0);
-  tx_power_adjust_str = sl_cli_get_argument_string(arguments, 1);
-  max_tx_power_lr_str = sl_cli_get_argument_string(arguments, 2);
-
-  if (!sli_try_parse_tx_power(tx_power_level_str, &tx_power_level)
-      || !sli_try_parse_tx_power(tx_power_adjust_str, &tx_power_adjust)
-      || !sli_try_parse_tx_power(max_tx_power_lr_str, &max_tx_power_lr)) {
-    app_log_info("Invalid integer input. Usage: set_powerlevel <iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>\r\n");
-    return;
-  }
+  tx_power_level = (zpal_tx_power_t)sl_cli_get_argument_int16(arguments, 0);
+  tx_power_adjust = (zpal_tx_power_t)sl_cli_get_argument_int16(arguments, 1);
+  max_tx_power_lr = (zpal_tx_power_t)sl_cli_get_argument_int16(arguments, 2);
 
   if (!sli_validate_powerlevel(tx_power_level, tx_power_adjust, max_tx_power_lr)) {
     app_log_info("Invalid power levels. iTxPowerLevelMax range: %d..%d, iTxPowerLevelAdjust range: %d..%d, iTxPowerLevelMaxLR range: %d..%d\r\n",
@@ -220,8 +208,8 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
                  (int)zpal_radio_get_maximum_tx_power(),
                  TX_POWER_LIMIT_MIN_DDBM,
                  TX_POWER_ADJUST_LIMIT_DDBM,
-                 (int)zpal_radio_get_minimum_lr_tx_power(),
-                 (int)zpal_radio_get_maximum_lr_tx_power());
+                 (int)DBM_TO_DDBM(zpal_radio_get_minimum_lr_tx_power()),
+                 (int)DBM_TO_DDBM(zpal_radio_get_maximum_lr_tx_power()));
     return;
   }
 
@@ -262,25 +250,6 @@ static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *re
   return false;
 }
 
-static bool sli_try_parse_tx_power(const char *value, zpal_tx_power_t *tx_power)
-{
-  char *end_ptr;
-  long parsed_value;
-
-  errno = 0;
-  parsed_value = strtol(value, &end_ptr, 0);
-  if ((0 != errno) || ('\0' != *end_ptr)) {
-    return false;
-  }
-
-  if ((parsed_value < INT16_MIN) || (parsed_value > INT16_MAX)) {
-    return false;
-  }
-
-  *tx_power = (zpal_tx_power_t)parsed_value;
-  return true;
-}
-
 static const char *sli_get_region_name(zpal_radio_region_t region)
 {
   switch (region) {
@@ -314,8 +283,8 @@ static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
       && (tx_power_level <= zpal_radio_get_maximum_tx_power())
       && (tx_power_adjust >= TX_POWER_LIMIT_MIN_DDBM)
       && (tx_power_adjust <= TX_POWER_ADJUST_LIMIT_DDBM)
-  && (max_tx_power_lr >= zpal_radio_get_minimum_lr_tx_power())
-  && (max_tx_power_lr <= zpal_radio_get_maximum_lr_tx_power());
+      && (max_tx_power_lr >= DBM_TO_DDBM(zpal_radio_get_minimum_lr_tx_power()))
+      && (max_tx_power_lr <= DBM_TO_DDBM(zpal_radio_get_maximum_lr_tx_power()));
 }
 
 static void sli_log_supported_regions(void)

--- a/app_cli.c
+++ b/app_cli.c
@@ -31,6 +31,7 @@
 // -----------------------------------------------------------------------------
 //                                   Includes
 // -----------------------------------------------------------------------------
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <strings.h>
@@ -38,8 +39,8 @@
 
 #ifdef SL_CATALOG_ZW_CLI_COMMON_PRESENT
 
-#include "MfgTokens.h"
 #include "ZAF_Common_interface.h"
+#include "repeater_config_nvm.h"
 #include "zaf_event_distributor_soc.h"
 #include "sl_cli.h"
 #include "app_log.h"
@@ -57,11 +58,17 @@ typedef struct {
   zpal_radio_region_t region;
 } cli_region_name_t;
 
+#define TX_POWER_LIMIT_MIN_DDBM     (-100)
+#define TX_POWER_ADJUST_LIMIT_DDBM  (100)
+
 // -----------------------------------------------------------------------------
 //                          Static Function Declarations
 // -----------------------------------------------------------------------------
 static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *region);
 static const char *sli_get_region_name(zpal_radio_region_t region);
+static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
+                                    zpal_tx_power_t tx_power_adjust,
+                                    zpal_tx_power_t max_tx_power_lr);
 static void sli_log_supported_regions(void);
 
 // -----------------------------------------------------------------------------
@@ -131,15 +138,92 @@ void cli_set_region(sl_cli_command_arg_t *arguments)
   }
 
   active_region = zpal_radio_get_region();
-  ZW_SetMfgTokenDataCountryRegion(&region);
+  if (!SaveApplicationRfRegion(region)) {
+    app_log_info("Failed to persist region %s.\r\n", sli_get_region_name(region));
+    return;
+  }
+
   if (region == active_region) {
-    app_log_info("Configured region set to %s. Region already active, no reboot required.\r\n",
+    app_log_info("Configured region set to %s in NVM. Region already active, no reboot required.\r\n",
                  sli_get_region_name(region));
     return;
   }
 
-  app_log_info("Configured region set to %s. Rebooting to apply the new region.\r\n",
+  app_log_info("Configured region set to %s in NVM. Rebooting to apply the new region.\r\n",
                sli_get_region_name(region));
+  zpal_reboot_with_info(ZAF_CONFIG_MANUFACTURER_ID, ZPAL_RESET_INFO_DEFAULT);
+}
+
+/******************************************************************************
+ * CLI - get_powerlevel: Read the persisted RF power configuration
+ *****************************************************************************/
+void cli_get_powerlevel(sl_cli_command_arg_t *arguments)
+{
+  zpal_tx_power_t tx_power_level;
+  zpal_tx_power_t tx_power_adjust;
+  zpal_tx_power_t max_tx_power_lr;
+
+  (void) arguments;
+
+  if (!ReadApplicationTxPowerlevel(&tx_power_level, &tx_power_adjust)
+      || !ReadApplicationMaxLRTxPwr(&max_tx_power_lr)) {
+    app_log_info("Power configuration is not available in NVM.\r\n");
+    return;
+  }
+
+  app_log_info("iTxPowerLevelMax=%d iTxPowerLevelAdjust=%d iTxPowerLevelMaxLR=%d\r\n",
+               (int)tx_power_level,
+               (int)tx_power_adjust,
+               (int)max_tx_power_lr);
+}
+
+/******************************************************************************
+ * CLI - set_powerlevel: Update the persisted RF power configuration
+ *****************************************************************************/
+void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
+{
+  SRadioConfig_t *radio_config = zaf_get_radio_config();
+  zpal_tx_power_t tx_power_level;
+  zpal_tx_power_t tx_power_adjust;
+  zpal_tx_power_t max_tx_power_lr;
+  bool requires_reboot;
+
+  if (sl_cli_get_argument_count(arguments) != 3) {
+    app_log_info("Usage: set_powerlevel <iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>\r\n");
+    return;
+  }
+
+  tx_power_level = (zpal_tx_power_t)sl_cli_get_argument_int32(arguments, 0);
+  tx_power_adjust = (zpal_tx_power_t)sl_cli_get_argument_int32(arguments, 1);
+  max_tx_power_lr = (zpal_tx_power_t)sl_cli_get_argument_int32(arguments, 2);
+
+  if (!sli_validate_powerlevel(tx_power_level, tx_power_adjust, max_tx_power_lr)) {
+    app_log_info("Invalid power levels. iTxPowerLevelMax range: %d..%d, iTxPowerLevelAdjust range: %d..%d, iTxPowerLevelMaxLR range: %d..%d\r\n",
+                 TX_POWER_LIMIT_MIN_DDBM,
+                 (int)zpal_radio_get_maximum_tx_power(),
+                 TX_POWER_LIMIT_MIN_DDBM,
+                 TX_POWER_ADJUST_LIMIT_DDBM,
+                 TX_POWER_LIMIT_MIN_DDBM,
+                 (int)zpal_radio_get_maximum_tx_power());
+    return;
+  }
+
+  if (!SaveApplicationTxPowerlevel(tx_power_level, tx_power_adjust)
+      || !SaveApplicationMaxLRTxPwr(max_tx_power_lr)) {
+    app_log_info("Failed to persist power configuration.\r\n");
+    return;
+  }
+
+  requires_reboot = (radio_config->iTxPowerLevelMax != tx_power_level)
+                 || (radio_config->iTxPowerLevelAdjust != tx_power_adjust)
+                 || (radio_config->iTxPowerLevelMaxLR != max_tx_power_lr);
+
+  if (!requires_reboot) {
+    app_log_info("Power configuration stored in NVM. Values are already active, no reboot required.\r\n");
+    return;
+  }
+
+  app_log_info("Power configuration stored in NVM. Rebooting to apply the new settings.\r\n");
   zpal_reboot_with_info(ZAF_CONFIG_MANUFACTURER_ID, ZPAL_RESET_INFO_DEFAULT);
 }
 
@@ -178,6 +262,18 @@ static const char *sli_get_region_name(zpal_radio_region_t region)
     case REGION_KR:    return "KR";
     default:           return "Unknown";
   }
+}
+
+static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
+                                    zpal_tx_power_t tx_power_adjust,
+                                    zpal_tx_power_t max_tx_power_lr)
+{
+  return (tx_power_level >= TX_POWER_LIMIT_MIN_DDBM)
+      && (tx_power_level <= zpal_radio_get_maximum_tx_power())
+      && (tx_power_adjust >= TX_POWER_LIMIT_MIN_DDBM)
+      && (tx_power_adjust <= TX_POWER_ADJUST_LIMIT_DDBM)
+      && (max_tx_power_lr >= TX_POWER_LIMIT_MIN_DDBM)
+      && (max_tx_power_lr <= zpal_radio_get_maximum_tx_power());
 }
 
 static void sli_log_supported_regions(void)

--- a/app_cli.c
+++ b/app_cli.c
@@ -31,7 +31,9 @@
 // -----------------------------------------------------------------------------
 //                                   Includes
 // -----------------------------------------------------------------------------
+#include <errno.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <strings.h>
@@ -66,6 +68,7 @@ typedef struct {
 //                          Static Function Declarations
 // -----------------------------------------------------------------------------
 static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *region);
+static bool sli_try_parse_tx_power(const char *value, zpal_tx_power_t *tx_power);
 static const char *sli_get_region_name(zpal_radio_region_t region);
 static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
                                     zpal_tx_power_t tx_power_adjust,
@@ -187,6 +190,9 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
   zpal_tx_power_t tx_power_level;
   zpal_tx_power_t tx_power_adjust;
   zpal_tx_power_t max_tx_power_lr;
+  const char *tx_power_level_str;
+  const char *tx_power_adjust_str;
+  const char *max_tx_power_lr_str;
   bool requires_reboot;
 
   if (sl_cli_get_argument_count(arguments) != 3) {
@@ -194,9 +200,16 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
     return;
   }
 
-  tx_power_level = (zpal_tx_power_t)sl_cli_get_argument_int32(arguments, 0);
-  tx_power_adjust = (zpal_tx_power_t)sl_cli_get_argument_int32(arguments, 1);
-  max_tx_power_lr = (zpal_tx_power_t)sl_cli_get_argument_int32(arguments, 2);
+  tx_power_level_str = sl_cli_get_argument_string(arguments, 0);
+  tx_power_adjust_str = sl_cli_get_argument_string(arguments, 1);
+  max_tx_power_lr_str = sl_cli_get_argument_string(arguments, 2);
+
+  if (!sli_try_parse_tx_power(tx_power_level_str, &tx_power_level)
+      || !sli_try_parse_tx_power(tx_power_adjust_str, &tx_power_adjust)
+      || !sli_try_parse_tx_power(max_tx_power_lr_str, &max_tx_power_lr)) {
+    app_log_info("Invalid integer input. Usage: set_powerlevel <iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>\r\n");
+    return;
+  }
 
   if (!sli_validate_powerlevel(tx_power_level, tx_power_adjust, max_tx_power_lr)) {
     app_log_info("Invalid power levels. iTxPowerLevelMax range: %d..%d, iTxPowerLevelAdjust range: %d..%d, iTxPowerLevelMaxLR range: %d..%d\r\n",
@@ -204,8 +217,8 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
                  (int)zpal_radio_get_maximum_tx_power(),
                  TX_POWER_LIMIT_MIN_DDBM,
                  TX_POWER_ADJUST_LIMIT_DDBM,
-                 TX_POWER_LIMIT_MIN_DDBM,
-                 (int)zpal_radio_get_maximum_tx_power());
+                 (int)zpal_radio_get_minimum_lr_tx_power(),
+                 (int)zpal_radio_get_maximum_lr_tx_power());
     return;
   }
 
@@ -246,6 +259,25 @@ static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *re
   return false;
 }
 
+static bool sli_try_parse_tx_power(const char *value, zpal_tx_power_t *tx_power)
+{
+  char *end_ptr;
+  long parsed_value;
+
+  errno = 0;
+  parsed_value = strtol(value, &end_ptr, 0);
+  if ((0 != errno) || ('\0' != *end_ptr)) {
+    return false;
+  }
+
+  if ((parsed_value < INT16_MIN) || (parsed_value > INT16_MAX)) {
+    return false;
+  }
+
+  *tx_power = (zpal_tx_power_t)parsed_value;
+  return true;
+}
+
 static const char *sli_get_region_name(zpal_radio_region_t region)
 {
   switch (region) {
@@ -273,8 +305,8 @@ static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
       && (tx_power_level <= zpal_radio_get_maximum_tx_power())
       && (tx_power_adjust >= TX_POWER_LIMIT_MIN_DDBM)
       && (tx_power_adjust <= TX_POWER_ADJUST_LIMIT_DDBM)
-      && (max_tx_power_lr >= TX_POWER_LIMIT_MIN_DDBM)
-      && (max_tx_power_lr <= zpal_radio_get_maximum_tx_power());
+  && (max_tx_power_lr >= zpal_radio_get_minimum_lr_tx_power())
+  && (max_tx_power_lr <= zpal_radio_get_maximum_lr_tx_power());
 }
 
 static void sli_log_supported_regions(void)

--- a/app_cli.c
+++ b/app_cli.c
@@ -45,6 +45,7 @@
 #include "repeater_config_nvm.h"
 #include "zaf_event_distributor_soc.h"
 #include "sl_cli.h"
+#include "sl_sleeptimer.h"
 #include "app_log.h"
 #include "ev_man.h"
 #include "events.h"
@@ -63,6 +64,7 @@ typedef struct {
 
 #define TX_POWER_LIMIT_MIN_DDBM     (-100)
 #define TX_POWER_ADJUST_LIMIT_DDBM  (100)
+#define CLI_REBOOT_DELAY_MS         (50)
 
 // -----------------------------------------------------------------------------
 //                          Static Function Declarations
@@ -70,6 +72,7 @@ typedef struct {
 static bool sli_try_parse_region_name(const char *value, zpal_radio_region_t *region);
 static bool sli_try_parse_tx_power(const char *value, zpal_tx_power_t *tx_power);
 static const char *sli_get_region_name(zpal_radio_region_t region);
+static void sli_reboot_after_cli_delay(void);
 static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
                                     zpal_tx_power_t tx_power_adjust,
                                     zpal_tx_power_t max_tx_power_lr);
@@ -155,7 +158,7 @@ void cli_set_region(sl_cli_command_arg_t *arguments)
 
   app_log_info("Configured region set to %s in NVM. Rebooting to apply the new region.\r\n",
                sli_get_region_name(region));
-  zpal_reboot_with_info(ZAF_CONFIG_MANUFACTURER_ID, ZPAL_RESET_INFO_DEFAULT);
+  sli_reboot_after_cli_delay();
 }
 
 /******************************************************************************
@@ -238,7 +241,7 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
   }
 
   app_log_info("Power configuration stored in NVM. Rebooting to apply the new settings.\r\n");
-  zpal_reboot_with_info(ZAF_CONFIG_MANUFACTURER_ID, ZPAL_RESET_INFO_DEFAULT);
+  sli_reboot_after_cli_delay();
 }
 
 // -----------------------------------------------------------------------------
@@ -295,6 +298,12 @@ static const char *sli_get_region_name(zpal_radio_region_t region)
     case REGION_KR:    return "KR";
     default:           return "Unknown";
   }
+}
+
+static void sli_reboot_after_cli_delay(void)
+{
+  sl_sleeptimer_delay_millisecond(CLI_REBOOT_DELAY_MS);
+  zpal_reboot_with_info(ZAF_CONFIG_MANUFACTURER_ID, ZPAL_RESET_INFO_DEFAULT);
 }
 
 static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,

--- a/app_cli.c
+++ b/app_cli.c
@@ -62,6 +62,7 @@ typedef struct {
 
 #define TX_POWER_LIMIT_MIN_DDBM     (-100)
 #define TX_POWER_ADJUST_LIMIT_DDBM  (100)
+#define LR_TX_POWER_LIMIT_MAX_DDBM  (200)
 #define DBM_TO_DDBM(value)          ((value) * 10)
 #define CLI_REBOOT_DELAY_MS         (50)
 
@@ -209,7 +210,7 @@ void cli_set_powerlevel(sl_cli_command_arg_t *arguments)
                  TX_POWER_LIMIT_MIN_DDBM,
                  TX_POWER_ADJUST_LIMIT_DDBM,
                  (int)DBM_TO_DDBM(zpal_radio_get_minimum_lr_tx_power()),
-                 (int)DBM_TO_DDBM(zpal_radio_get_maximum_lr_tx_power()));
+                 LR_TX_POWER_LIMIT_MAX_DDBM);
     return;
   }
 
@@ -284,7 +285,7 @@ static bool sli_validate_powerlevel(zpal_tx_power_t tx_power_level,
       && (tx_power_adjust >= TX_POWER_LIMIT_MIN_DDBM)
       && (tx_power_adjust <= TX_POWER_ADJUST_LIMIT_DDBM)
       && (max_tx_power_lr >= DBM_TO_DDBM(zpal_radio_get_minimum_lr_tx_power()))
-      && (max_tx_power_lr <= DBM_TO_DDBM(zpal_radio_get_maximum_lr_tx_power()));
+      && (max_tx_power_lr <= LR_TX_POWER_LIMIT_MAX_DDBM);
 }
 
 static void sli_log_supported_regions(void)

--- a/autogen/sl_cli_command_table.c
+++ b/autogen/sl_cli_command_table.c
@@ -174,7 +174,7 @@ static const sl_cli_command_info_t cli_cmd__set_powerlevel = \
   SL_CLI_COMMAND(cli_set_powerlevel,
                  "Set the configured RF power values in NVM",
                   "<iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>",
-                 {SL_CLI_ARG_INT32, SL_CLI_ARG_INT32, SL_CLI_ARG_INT32, SL_CLI_ARG_END, });
+                 {SL_CLI_ARG_STRING, SL_CLI_ARG_ADDITIONAL, SL_CLI_ARG_END, });
 
 static const sl_cli_command_info_t cli_cmd__bootloader = \
   SL_CLI_COMMAND(cli_bootloader,

--- a/autogen/sl_cli_command_table.c
+++ b/autogen/sl_cli_command_table.c
@@ -174,7 +174,7 @@ static const sl_cli_command_info_t cli_cmd__set_powerlevel = \
   SL_CLI_COMMAND(cli_set_powerlevel,
                  "Set the configured RF power values in NVM",
                   "<iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>",
-                 {SL_CLI_ARG_STRING, SL_CLI_ARG_ADDITIONAL, SL_CLI_ARG_END, });
+                 {SL_CLI_ARG_INT16, SL_CLI_ARG_INT16, SL_CLI_ARG_INT16, SL_CLI_ARG_END, });
 
 static const sl_cli_command_info_t cli_cmd__bootloader = \
   SL_CLI_COMMAND(cli_bootloader,

--- a/autogen/sl_cli_command_table.c
+++ b/autogen/sl_cli_command_table.c
@@ -154,25 +154,25 @@ static const sl_cli_command_info_t cli_cmd__get_dsk = \
 
 static const sl_cli_command_info_t cli_cmd__get_region = \
   SL_CLI_COMMAND(cli_get_region,
-                 "Get the used region",
+                 "Get the configured region",
                   "",
                  {SL_CLI_ARG_END, });
 
 static const sl_cli_command_info_t cli_cmd__set_region = \
   SL_CLI_COMMAND(cli_set_region,
-                 "Set the configured region in NVM",
+                 "Set the configured region",
                   "<region>",
                  {SL_CLI_ARG_STRING, SL_CLI_ARG_END, });
 
 static const sl_cli_command_info_t cli_cmd__get_powerlevel = \
   SL_CLI_COMMAND(cli_get_powerlevel,
-                 "Get the configured RF power values from NVM",
+                 "Get the configured RF power values",
                   "",
                  {SL_CLI_ARG_END, });
 
 static const sl_cli_command_info_t cli_cmd__set_powerlevel = \
   SL_CLI_COMMAND(cli_set_powerlevel,
-                 "Set the configured RF power values in NVM",
+                 "Set the configured RF power values",
                   "<iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>",
                  {SL_CLI_ARG_INT16, SL_CLI_ARG_INT16, SL_CLI_ARG_INT16, SL_CLI_ARG_END, });
 

--- a/autogen/sl_cli_command_table.c
+++ b/autogen/sl_cli_command_table.c
@@ -127,6 +127,8 @@ void cli_factory_reset(sl_cli_command_arg_t *arguments);
 void cli_get_dsk(sl_cli_command_arg_t *arguments);
 void cli_get_region(sl_cli_command_arg_t *arguments);
 void cli_set_region(sl_cli_command_arg_t *arguments);
+void cli_get_powerlevel(sl_cli_command_arg_t *arguments);
+void cli_set_powerlevel(sl_cli_command_arg_t *arguments);
 void cli_bootloader(sl_cli_command_arg_t *arguments);
 
 // Command structs. Names are in the format : cli_cmd_{command group name}_{command name}
@@ -158,9 +160,21 @@ static const sl_cli_command_info_t cli_cmd__get_region = \
 
 static const sl_cli_command_info_t cli_cmd__set_region = \
   SL_CLI_COMMAND(cli_set_region,
-                 "Set the configured region token",
+                 "Set the configured region in NVM",
                   "<region>",
                  {SL_CLI_ARG_STRING, SL_CLI_ARG_END, });
+
+static const sl_cli_command_info_t cli_cmd__get_powerlevel = \
+  SL_CLI_COMMAND(cli_get_powerlevel,
+                 "Get the configured RF power values from NVM",
+                  "",
+                 {SL_CLI_ARG_END, });
+
+static const sl_cli_command_info_t cli_cmd__set_powerlevel = \
+  SL_CLI_COMMAND(cli_set_powerlevel,
+                 "Set the configured RF power values in NVM",
+                  "<iTxPowerLevelMax> <iTxPowerLevelAdjust> <iTxPowerLevelMaxLR>",
+                 {SL_CLI_ARG_INT32, SL_CLI_ARG_INT32, SL_CLI_ARG_INT32, SL_CLI_ARG_END, });
 
 static const sl_cli_command_info_t cli_cmd__bootloader = \
   SL_CLI_COMMAND(cli_bootloader,
@@ -179,6 +193,8 @@ const sl_cli_command_entry_t sl_cli_default_command_table[] = {
   { "get_dsk", &cli_cmd__get_dsk, false },
   { "get_region", &cli_cmd__get_region, false },
   { "set_region", &cli_cmd__set_region, false },
+  { "get_powerlevel", &cli_cmd__get_powerlevel, false },
+  { "set_powerlevel", &cli_cmd__set_powerlevel, false },
   { "bootloader", &cli_cmd__bootloader, false },
   { NULL, NULL, false },
 };

--- a/nc_controller_soc_repeater.slcp
+++ b/nc_controller_soc_repeater.slcp
@@ -20,6 +20,7 @@ source:
 - {path: app.c}
 - {path: main.c}
 - {path: app_cli.c}
+- {path: repeater_config_nvm.c}
 tag: [prebuilt_demo]
 include:
 - path: .

--- a/repeater_config_nvm.c
+++ b/repeater_config_nvm.c
@@ -1,0 +1,133 @@
+#include "repeater_config_nvm.h"
+
+#include <string.h>
+
+#include "ZAF_nvm_app.h"
+
+#define FILE_ID_APPLICATIONCONFIGURATION  104
+
+typedef struct __attribute__((packed)) {
+  zpal_radio_region_t     rfRegion;
+  zpal_tx_power_t         iTxPower;
+  zpal_tx_power_t         ipower0dbmMeasured;
+  zpal_tx_power_t         maxTxPower;
+} SApplicationConfiguration;
+
+static bool object_exists(zpal_nvm_object_key_t key)
+{
+  size_t object_size = 0;
+
+  return (ZPAL_STATUS_OK == ZAF_nvm_app_get_object_size(key, &object_size));
+}
+
+static bool read_application_configuration(SApplicationConfiguration *configuration)
+{
+  if (!object_exists(FILE_ID_APPLICATIONCONFIGURATION)) {
+    return false;
+  }
+
+  return (ZPAL_STATUS_OK == ZAF_nvm_app_read(FILE_ID_APPLICATIONCONFIGURATION,
+                                             configuration,
+                                             sizeof(*configuration)));
+}
+
+static bool write_application_configuration(const SApplicationConfiguration *configuration)
+{
+  return (ZPAL_STATUS_OK == ZAF_nvm_app_write(FILE_ID_APPLICATIONCONFIGURATION,
+                                              configuration,
+                                              sizeof(*configuration)));
+}
+
+bool RepeaterConfigExists(void)
+{
+  return object_exists(FILE_ID_APPLICATIONCONFIGURATION);
+}
+
+bool RepeaterConfigWriteDefaults(const SRadioConfig_t *radio_config)
+{
+  SApplicationConfiguration configuration;
+
+  memset(&configuration, 0, sizeof(configuration));
+  configuration.rfRegion = radio_config->eRegion;
+  configuration.iTxPower = radio_config->iTxPowerLevelMax;
+  configuration.ipower0dbmMeasured = radio_config->iTxPowerLevelAdjust;
+  configuration.maxTxPower = radio_config->iTxPowerLevelMaxLR;
+
+  return write_application_configuration(&configuration);
+}
+
+bool SaveApplicationRfRegion(zpal_radio_region_t rf_region)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  configuration.rfRegion = rf_region;
+  return write_application_configuration(&configuration);
+}
+
+bool ReadApplicationRfRegion(zpal_radio_region_t *rf_region)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  *rf_region = configuration.rfRegion;
+  return true;
+}
+
+bool SaveApplicationTxPowerlevel(zpal_tx_power_t tx_power_level,
+                                 zpal_tx_power_t tx_power_adjust)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  configuration.iTxPower = tx_power_level;
+  configuration.ipower0dbmMeasured = tx_power_adjust;
+  return write_application_configuration(&configuration);
+}
+
+bool ReadApplicationTxPowerlevel(zpal_tx_power_t *tx_power_level,
+                                 zpal_tx_power_t *tx_power_adjust)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  *tx_power_level = configuration.iTxPower;
+  *tx_power_adjust = configuration.ipower0dbmMeasured;
+  return true;
+}
+
+bool SaveApplicationMaxLRTxPwr(zpal_tx_power_t max_tx_power_lr)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  configuration.maxTxPower = max_tx_power_lr;
+  return write_application_configuration(&configuration);
+}
+
+bool ReadApplicationMaxLRTxPwr(zpal_tx_power_t *max_tx_power_lr)
+{
+  SApplicationConfiguration configuration;
+
+  if (!read_application_configuration(&configuration)) {
+    return false;
+  }
+
+  *max_tx_power_lr = configuration.maxTxPower;
+  return true;
+}

--- a/repeater_config_nvm.h
+++ b/repeater_config_nvm.h
@@ -1,0 +1,22 @@
+#ifndef REPEATER_CONFIG_NVM_H
+#define REPEATER_CONFIG_NVM_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "ZW_application_transport_interface.h"
+
+bool RepeaterConfigExists(void);
+bool RepeaterConfigWriteDefaults(const SRadioConfig_t *radio_config);
+
+bool SaveApplicationRfRegion(zpal_radio_region_t rf_region);
+bool ReadApplicationRfRegion(zpal_radio_region_t *rf_region);
+
+bool SaveApplicationTxPowerlevel(zpal_tx_power_t tx_power_level,
+                                 zpal_tx_power_t tx_power_adjust);
+bool ReadApplicationTxPowerlevel(zpal_tx_power_t *tx_power_level,
+                                 zpal_tx_power_t *tx_power_adjust);
+
+bool SaveApplicationMaxLRTxPwr(zpal_tx_power_t max_tx_power_lr);
+bool ReadApplicationMaxLRTxPwr(zpal_tx_power_t *max_tx_power_lr);
+
+#endif


### PR DESCRIPTION
Using the Mfg token was not a good approach as it won't let us change the setting after writing once.